### PR TITLE
Group form submission requests in single transaction.

### DIFF
--- a/transaction_reports.conf
+++ b/transaction_reports.conf
@@ -21,39 +21,16 @@ yfactor  = 1
 yscale   = log
 
 
-[save_form_mean]
-title   = Mean duration of save_form transactions
+[update_case_form_submission_mean]
+title   = Mean duration of update_case_form_submission transactions
 ylabel  = Duration in seconds
-stats   = tr_save_form.mean
+stats   = tr_update_case_form_submission.mean
 legend  = Transactions
 yfactor = 1000
 
-
-[update_cases_mean]
-title   = Mean duration of update_cases transactions
+[create_case_form_submission_mean]
+title   = Mean duration of create_case_form_submission transactions
 ylabel  = Duration in seconds
-stats   = tr_update_cases.mean
-legend  = Transactions
-yfactor = 1000
-
-[update_sync_record_mean]
-title   = Mean duration of update_sync_record transactions
-ylabel  = Duration in seconds
-stats   = tr_update_sync_record.mean
-legend  = Transactions
-yfactor = 1000
-
-
-[new_case_mean]
-title   = Mean duration of new_case transactions
-ylabel  = Duration in seconds
-stats   = tr_new_case.mean
-legend  = Transactions
-yfactor = 1000
-
-[update_sync_record_new_case_mean]
-title   = Mean duration of update_sync_record_new_case transactions
-ylabel  = Duration in seconds
-stats   = tr_update_sync_record_new_case.mean
+stats   = tr_create_case_form_submission.mean
 legend  = Transactions
 yfactor = 1000

--- a/tsung/templates/tsung-form-submission.xml.j2
+++ b/tsung/templates/tsung-form-submission.xml.j2
@@ -38,18 +38,16 @@
                 <var name="form_json" />
             </setdynvars>
 
-            <!-- Each transaction gets its own statistics and reports -->
-            <transaction name="connection">
-                <request>
-                    <pgsql type="connect" database="{{ pg_database }}" username="{{ pg_username }}" />
-                </request>
-            </transaction>
+            <request>
+                <pgsql type="connect" database="{{ pg_database }}" username="{{ pg_username }}" />
+            </request>
 
-
-            &save_form;
             <thinktime value="1" random="true"></thinktime>
-            &new_case;
-            &update_sync_record_new_case;
+            <transaction name="new_case_form_submission">
+                &save_form;
+                &new_case;
+                &update_sync_record_new_case;
+            </transaction>
 
             <request><pgsql type="close"></pgsql></request>
         </session>
@@ -67,18 +65,17 @@
                 <var name="form_json" />
             </setdynvars>
 
-            <!-- Each transaction gets its own statistics and reports -->
-            <transaction name="connection">
-                <request>
-                    <pgsql type="connect" database="{{ pg_database }}" username="{{ pg_username }}" />
-                </request>
-            </transaction>
+            <request>
+                <pgsql type="connect" database="{{ pg_database }}" username="{{ pg_username }}" />
+            </request>
 
-            &validation;
-            &save_form;
             <thinktime value="1" random="true"></thinktime>
-            &update_cases;
-            &update_sync_record;
+            <transaction name="update_case_form_submission">
+                &validation;
+                &save_form;
+                &update_cases;
+                &update_sync_record;
+            </transaction>
 
             <request><pgsql type="close"></pgsql></request>
         </session>

--- a/tsung/transactions/new_case.xml
+++ b/tsung/transactions/new_case.xml
@@ -1,16 +1,14 @@
-<transaction name="new_case">
-    <request subst="true">
-        <dyn_variable name="case_id" pgsql_expr="data_row[1][1]"/>
-        <pgsql type="sql">
-            INSERT INTO casedata (domain, owner_id, case_json)
-            VALUES ('%%_domain%%', '%%_user_id%%', '%%generator:case_json%%')
-            RETURNING id;
-        </pgsql>
-    </request>
-    <request subst="true">
-        <pgsql type="sql">
-            INSERT INTO case_form (case_id, form_id)
-            VALUES ('%%_case_id%%', '%%_form_id%%');
-        </pgsql>
-    </request>
-</transaction>
+<request subst="true">
+    <dyn_variable name="case_id" pgsql_expr="data_row[1][1]"/>
+    <pgsql type="sql">
+        INSERT INTO casedata (domain, owner_id, case_json)
+        VALUES ('%%_domain%%', '%%_user_id%%', '%%generator:case_json%%')
+        RETURNING id;
+    </pgsql>
+</request>
+<request subst="true">
+    <pgsql type="sql">
+        INSERT INTO case_form (case_id, form_id)
+        VALUES ('%%_case_id%%', '%%_form_id%%');
+    </pgsql>
+</request>

--- a/tsung/transactions/save_form.xml
+++ b/tsung/transactions/save_form.xml
@@ -1,10 +1,8 @@
-<transaction name="save_form">
-    <request subst="true">
-        <dyn_variable name="form_id" pgsql_expr="data_row[1][1]"/>
-        <pgsql type="sql">
-            INSERT INTO formdata (domain, user_id, form_json)
-            VALUES ('%%_domain%%', '%%_user_id%%', '%%_form_json%%')
-            RETURNING id;
-        </pgsql>
-    </request>
-</transaction>
+<request subst="true">
+    <dyn_variable name="form_id" pgsql_expr="data_row[1][1]"/>
+    <pgsql type="sql">
+        INSERT INTO formdata (domain, user_id, form_json)
+        VALUES ('%%_domain%%', '%%_user_id%%', '%%_form_json%%')
+        RETURNING id;
+    </pgsql>
+</request>

--- a/tsung/transactions/update_cases.xml
+++ b/tsung/transactions/update_cases.xml
@@ -1,15 +1,14 @@
-<transaction name="update_cases">
-    <request subst="true">
-        <pgsql type="sql">
-            UPDATE casedata
-            SET case_json='%%_case_json%%', owner_id='%%_user_id%%', server_modified_on=now()
-            WHERE id = '%%_case_id%%';
-        </pgsql>
-    </request>
-    <request subst="true">
-        <pgsql type="sql">
-            INSERT INTO case_form (case_id, form_id)
-            VALUES ('%%_case_id%%', '%%_form_id%%');
-        </pgsql>
-    </request>
-</transaction>
+<request subst="true">
+    <pgsql type="sql">
+        UPDATE casedata
+        SET case_json='%%_case_json%%', owner_id='%%_user_id%%', server_modified_on=now()
+        WHERE id = '%%_case_id%%';
+    </pgsql>
+</request>
+<request subst="true">
+    <pgsql type="sql">
+        INSERT INTO case_form (case_id, form_id)
+        VALUES ('%%_case_id%%', '%%_form_id%%');
+    </pgsql>
+</request>
+

--- a/tsung/transactions/update_sync_record.xml
+++ b/tsung/transactions/update_sync_record.xml
@@ -1,28 +1,26 @@
-<transaction name="update_sync_record">
-    <!-- Previous synclog id -->
-    <request subst="true">
-        <dyn_variable name="previous_log_id" pgsql_expr="data_row[1][1]"/>
-        <pgsql type="sql">
-            SELECT id FROM synclog WHERE user_id = '%%_user_id%%' LIMIT 1
-        </pgsql>
-    </request>
+<!-- Previous synclog id -->
+<request subst="true">
+    <dyn_variable name="previous_log_id" pgsql_expr="data_row[1][1]"/>
+    <pgsql type="sql">
+        SELECT id FROM synclog WHERE user_id = '%%_user_id%%' LIMIT 1
+    </pgsql>
+</request>
 
-    <!-- Insert new synclog -->
-    <request subst="true">
-        <dyn_variable name="synclog_id" pgsql_expr="data_row[1][1]"/>
-        <pgsql type="sql">
-            INSERT INTO synclog (user_id, previous_log_id, hash, owner_ids_on_phone)
-            VALUES ('%%_user_id%%', '%%generator:uuid%%', 'b22c7670ef488a633d337593ce8d4efa', '{"%%_owner_id%%", "%%_user_id%%"}')
-            RETURNING id;
-        </pgsql>
-    </request>
+<!-- Insert new synclog -->
+<request subst="true">
+    <dyn_variable name="synclog_id" pgsql_expr="data_row[1][1]"/>
+    <pgsql type="sql">
+        INSERT INTO synclog (user_id, previous_log_id, hash, owner_ids_on_phone)
+        VALUES ('%%_user_id%%', '%%generator:uuid%%', 'b22c7670ef488a633d337593ce8d4efa', '{"%%_owner_id%%", "%%_user_id%%"}')
+        RETURNING id;
+    </pgsql>
+</request>
 
-    <!-- Update reference of case to synclogs -->
-    <request subst="true">
-        <pgsql type="sql">
-            INSERT INTO synclog_cases (synclog_id, case_id, is_dependent)
-            VALUES ('%%_synclog_id%%', '%%generator:uuid%%', FALSE)
-        </pgsql>
-    </request>
-</transaction>
+<!-- Update reference of case to synclogs -->
+<request subst="true">
+    <pgsql type="sql">
+        INSERT INTO synclog_cases (synclog_id, case_id, is_dependent)
+        VALUES ('%%_synclog_id%%', '%%generator:uuid%%', FALSE)
+    </pgsql>
+</request>
 

--- a/tsung/transactions/update_sync_record_new_case.xml
+++ b/tsung/transactions/update_sync_record_new_case.xml
@@ -1,29 +1,27 @@
-<transaction name="update_sync_record_new_case">
-    <!-- Previous synclog id -->
-    <request subst="true">
-        <dyn_variable name="previous_log_id" pgsql_expr="data_row[1][1]"/>
-        <pgsql type="sql">
-            SELECT id FROM synclog WHERE user_id = '%%_user_id%%' LIMIT 1
-        </pgsql>
-    </request>
+<!-- Previous synclog id -->
+<request subst="true">
+    <dyn_variable name="previous_log_id" pgsql_expr="data_row[1][1]"/>
+    <pgsql type="sql">
+        SELECT id FROM synclog WHERE user_id = '%%_user_id%%' LIMIT 1
+    </pgsql>
+</request>
 
-    <!-- Insert new synclog -->
-    <request subst="true">
-        <dyn_variable name="synclog_id" pgsql_expr="data_row[1][1]"/>
-        <pgsql type="sql">
-            INSERT INTO synclog (user_id, hash, owner_ids_on_phone)
-            VALUES ('%%_user_id%%', 'b22c7670ef488a633d337593ce8d4efa', '{"%%_user_id%%"}')
-            RETURNING id;
-        </pgsql>
-    </request>
+<!-- Insert new synclog -->
+<request subst="true">
+    <dyn_variable name="synclog_id" pgsql_expr="data_row[1][1]"/>
+    <pgsql type="sql">
+        INSERT INTO synclog (user_id, hash, owner_ids_on_phone)
+        VALUES ('%%_user_id%%', 'b22c7670ef488a633d337593ce8d4efa', '{"%%_user_id%%"}')
+        RETURNING id;
+    </pgsql>
+</request>
 
-    <!-- Update reference of case to synclogs -->
-    <request subst="true">
-        <pgsql type="sql">
-            INSERT INTO synclog_cases (synclog_id, case_id, is_dependent)
-            VALUES ('%%_synclog_id%%', '%%generator:uuid%%', FALSE)
-        </pgsql>
-    </request>
-</transaction>
+<!-- Update reference of case to synclogs -->
+<request subst="true">
+    <pgsql type="sql">
+        INSERT INTO synclog_cases (synclog_id, case_id, is_dependent)
+        VALUES ('%%_synclog_id%%', '%%generator:uuid%%', FALSE)
+    </pgsql>
+</request>
 
 

--- a/tsung/transactions/validation.xml
+++ b/tsung/transactions/validation.xml
@@ -1,16 +1,13 @@
-<transaction name="validation">
-    <!-- get_case_domain, get_case_owner -->
-    <request subst="true">
-        <dyn_variable name="owner_id" pgsql_expr="data_row[1][1]"/>
-        <dyn_variable name="domain" pgsql_expr="data_row[1][2]"/>
-        <pgsql type="sql">
-            SELECT owner_id, domain FROM casedata where id = '%%_case_id%%' limit 1
+<!-- get_case_domain, get_case_owner -->
+<request subst="true">
+    <dyn_variable name="owner_id" pgsql_expr="data_row[1][1]"/>
+    <dyn_variable name="domain" pgsql_expr="data_row[1][2]"/>
+    <pgsql type="sql">
+        SELECT owner_id, domain FROM casedata where id = '%%_case_id%%' limit 1
 
-            <!-- Validate that user and domain exist 
-            SELECT id FROM users where ?.user_id = '%%_user_id%%';
-            SELECT id FROM domains where ?.domain = '%%_domain%%';
-            -->
-        </pgsql>
-    </request>
-
-</transaction>
+        <!-- Validate that user and domain exist
+        SELECT id FROM users where ?.user_id = '%%_user_id%%';
+        SELECT id FROM domains where ?.domain = '%%_domain%%';
+        -->
+    </pgsql>
+</request>


### PR DESCRIPTION
Currently, we have the requests broken up into many transactions. I thought it might be useful to group all the requests related to:
1. Submitting a form that creates a new case
2. Submitting a form that updates a case
It would be nice to be able to view these higher level transaction times, and the more granular level currently we have, but doesn't seem to be a way to aggregate specific transactions in tsung's reports, and nesting transactions is also not allowed.

Another thing worth noting is that I had to remove the randomly occurring think times from within the middle of the sessions, because think time is included in transaction time. I put them at the beginning of the sessions instead, which will at least create a somewhat bumpy arrival time of users. Let me know if you think any of these changes are misguided.

@snopoke 
FYI @benrudolph @czue 
(review with `w=1`)
