### PR TITLE
Improve db_to_csv time efficiency

### DIFF
--- a/db_to_csv.py
+++ b/db_to_csv.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import os
 import settings
+import uuid
 
 from utils import psql, execute_query
 
@@ -13,21 +14,40 @@ class RowToCSV(object):
         self.limit = limit
 
     def copy(self):
-        sql = "\COPY (SELECT {columns} FROM {table} ORDER BY random() LIMIT {limit}) TO '{dest}' WITH (FORMAT TEXT, DELIMITER ',')".format(
-            table=self.table,
-            columns=','.join(self.columns),
-            dest=self.dest,
+
+        # Erase the contents of the file
+        open(self.dest, 'w').close()
+
+        LOWEST_UUID = "00000000-0000-0000-0000-000000000000"
+        KEEP = 3
+
+        for i in xrange(self.limit):
+            got_a_row = False
+            while not got_a_row:
+                high_uuid = str(uuid.uuid4())
+                low_uuid = high_uuid[:KEEP] + LOWEST_UUID[KEEP:]
+                sql = "\COPY (SELECT {columns} FROM {table} WHERE id BETWEEN '{low_uuid}' and '{high_uuid}' ORDER BY id DESC LIMIT 1) TO stdout WITH (FORMAT TEXT, DELIMITER ',')".format(
+                    table=self.table,
+                    columns=','.join(self.columns),
+                    low_uuid=low_uuid,
+                    high_uuid=high_uuid,
+                )
+                cmd = psql(c=sql)
+                if cmd.stderr:
+                    print(cmd.stderr)
+                    break
+                else:
+                    if cmd.stdout:
+                        with open(self.dest, "a") as file:
+                            file.write(cmd.stdout)
+                        got_a_row = True
+                        if i+1 % 100 == 0:
+                            print("Copied {} of {} rows.".format(i, self.limit))
+
+        print("Successfully copied {limit} rows to {dest}".format(
             limit=self.limit,
-        )
-        cmd = psql(c=sql, _bg=True)
-        if cmd.stderr:
-            print(cmd.stderr)
-        else:
-            print(cmd.stdout)
-            print("Successfully copied {limit} rows to {dest}".format(
-                limit=self.limit,
-                dest=self.dest,
-            ))
+            dest=self.dest,
+        ))
 
 
 class FormToCSV(RowToCSV):


### PR DESCRIPTION
The `SELECT {columns} FROM {table} ORDER BY random() LIMIT {limit}` query was prohibitively slow (I killed the query after 2 hours) because it required sorting every row in the table (100,000,000 in the biggest test we're trying to run). I came up with what I think is a pretty good solution for choosing random rows without iterating over the whole table that takes advantage of uuids. The worst case is still `O(logn * n)`, but in the average case we only sort `n / (16^3)` of the rows for each random selection (exponent can be tuned).

The primary disadvantage here is that it requires a query for each random row we want, but I don't _think_ this will be prohibitive. Eventually I plan on leveraging this query to choose a random case to update for each user's session in the tsung tests.

In brief, the query works by selecting the first row who's uuid is less than a random uuid. To avoid sorting all rows less than the random uuid, we choose a lower limit that we can expect (give the random distribution of uuid4s) to encompass a reasonable number of rows.

@snopoke @czue @benrudolph 
