### PR TITLE
make running only a group of tests easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ Once your settings are updated you can run tests as follows
 
 ```
 $ py.test  # run all tests
-$ py.test test_models  # run model tests
-$ py.test test_basic  # run test_models.test_basic
+$ py.test -k test_models  # run model tests
+$ py.test -k test_basic  # run test_models.test_basic
+$ py.test -m <sql or couch> # only run the sql or couch tests
+$ py.test --rowsize <form or case> # run the rowsize form or case tests
+
 ```
 
 

--- a/prototype/tests/conftest.py
+++ b/prototype/tests/conftest.py
@@ -9,16 +9,23 @@ from mobile_endpoint.models import db
 
 @pytest.fixture(scope="session")
 def testapp():
-    from mobile_endpoint.backends.couch.db import init_dbs
     app = create_app('testconfig.py')
 
     db.app = app
-    with app.app_context():
-        upgrade()
-        # init couch DBs
-        init_dbs()
-
     return app
+
+
+@pytest.fixture(scope="session")
+def sqldb(testapp):
+    with testapp.app_context():
+        upgrade()
+
+
+@pytest.fixture(scope="session")
+def couchdb(testapp):
+    from mobile_endpoint.backends.couch.db import init_dbs
+    with testapp.app_context():
+        init_dbs()
 
 
 @pytest.fixture()

--- a/prototype/tests/conftest.py
+++ b/prototype/tests/conftest.py
@@ -6,6 +6,28 @@ patch_path()
 from mobile_endpoint import create_app
 from mobile_endpoint.models import db
 
+couch = pytest.mark.couch
+sql = pytest.mark.sql
+rowsize = pytest.mark.rowsize
+
+
+def pytest_addoption(parser):
+    parser.addoption("--rowsize", action="store", metavar="model",
+        help="only run row size tests")
+
+
+def pytest_runtest_setup(item):
+    rowsize_marker = item.get_marker("rowsize")
+    run_rowsize_tests = item.config.getoption("--rowsize")
+    if rowsize_marker:
+        model = rowsize_marker.args[0]
+        if not run_rowsize_tests:
+            pytest.skip("need --rowsize option to run")
+        if model != run_rowsize_tests:
+            pytest.skip("only running tests for model: {}".format(run_rowsize_tests))
+    elif run_rowsize_tests:
+        pytest.skip("only running rowsize tests")
+
 
 @pytest.fixture(scope="session")
 def testapp():

--- a/prototype/tests/couch/test_config.py
+++ b/prototype/tests/couch/test_config.py
@@ -1,9 +1,11 @@
 import uuid
 import pytest
 from mobile_endpoint.backends.couch.models import CouchForm
+from tests.conftest import couch
 
 
 @pytest.mark.usefixtures("testapp", "couchdb")
+@couch
 class TestConfig(object):
 
     def test_setting(self, testapp):

--- a/prototype/tests/couch/test_config.py
+++ b/prototype/tests/couch/test_config.py
@@ -3,7 +3,7 @@ import pytest
 from mobile_endpoint.backends.couch.models import CouchForm
 
 
-@pytest.mark.usefixtures("testapp")
+@pytest.mark.usefixtures("testapp", "couchdb")
 class TestConfig(object):
 
     def test_setting(self, testapp):

--- a/prototype/tests/couch/test_receiver.py
+++ b/prototype/tests/couch/test_receiver.py
@@ -2,10 +2,12 @@ import pytest
 from mobile_endpoint.backends.couch.models import CouchForm
 from mobile_endpoint.models import FormData, CaseData, Synclog
 from mobile_endpoint.synclog.checksum import Checksum
+from tests.conftest import couch
 from tests.test_receiver import ReceiverTestMixin, DOMAIN
 
 
 @pytest.mark.usefixtures("testapp", "client", "couchdb", "db_reset")
+@couch
 class TestCouchReceiver(ReceiverTestMixin):
 
     def _get_backend(self):

--- a/prototype/tests/couch/test_receiver.py
+++ b/prototype/tests/couch/test_receiver.py
@@ -3,6 +3,7 @@ from mobile_endpoint.backends.couch.models import CouchForm
 from mobile_endpoint.models import FormData, CaseData, Synclog
 from mobile_endpoint.synclog.checksum import Checksum
 from tests.conftest import couch
+from tests.mock import BACKEND_COUCH
 from tests.test_receiver import ReceiverTestMixin, DOMAIN
 
 
@@ -11,7 +12,7 @@ from tests.test_receiver import ReceiverTestMixin, DOMAIN
 class TestCouchReceiver(ReceiverTestMixin):
 
     def _get_backend(self):
-        return 'couch'
+        return BACKEND_COUCH
 
     def _assert_form(self, form_id, user_id, synclog_id=None):
         form = CouchForm.get(form_id)

--- a/prototype/tests/couch/test_receiver.py
+++ b/prototype/tests/couch/test_receiver.py
@@ -5,7 +5,7 @@ from mobile_endpoint.synclog.checksum import Checksum
 from tests.test_receiver import ReceiverTestMixin, DOMAIN
 
 
-@pytest.mark.usefixtures("testapp", "client", "db_reset")
+@pytest.mark.usefixtures("testapp", "client", "couchdb", "db_reset")
 class TestCouchReceiver(ReceiverTestMixin):
 
     def _get_backend(self):

--- a/prototype/tests/mock.py
+++ b/prototype/tests/mock.py
@@ -24,6 +24,10 @@ MOCK_FORM = """<?xml version='1.0' ?>
 </system>"""
 
 
+BACKEND_SQL = 'sql'
+BACKEND_COUCH = 'couch'
+
+
 def post_case_blocks(backend, client, case_blocks, form_extras=None, domain=None):
     """
     Post case blocks.
@@ -36,8 +40,8 @@ def post_case_blocks(backend, client, case_blocks, form_extras=None, domain=None
 
     domain = domain or form_extras.pop('domain', None)
     submit_url = {
-        'sql': 'ota/receiver/{}'.format(domain),
-        'couch': 'ota/couch-receiver/{}'.format(domain),
+        BACKEND_SQL: 'ota/receiver/{}'.format(domain),
+        BACKEND_COUCH: 'ota/couch-receiver/{}'.format(domain),
     }[backend]
 
     now = json_format_datetime(datetime.utcnow())

--- a/prototype/tests/sql/test_models.py
+++ b/prototype/tests/sql/test_models.py
@@ -14,7 +14,7 @@ from tests.conftest import delete_all_data
 from tests.utils import create_synclog
 
 
-@pytest.mark.usefixtures("testapp", "db_reset")
+@pytest.mark.usefixtures("testapp", "sqldb", "db_reset")
 class TestModels(object):
     def test_basic(self, testapp):
         form = FormData(id=str(uuid4()), domain='test', received_on=datetime.utcnow(),
@@ -74,7 +74,7 @@ class TestModels(object):
         assert CaseData.query.get(case_id).version == 3
 
 
-@pytest.mark.usefixtures("testapp")
+@pytest.mark.usefixtures("testapp", "sqldb")
 class TestDetermineRowSizes(object):
     @pytest.mark.skipif(True, reason="Not a real test. Only run this manually")
     def test_table_size_form(self):

--- a/prototype/tests/sql/test_models.py
+++ b/prototype/tests/sql/test_models.py
@@ -10,11 +10,12 @@ import pytest
 from mobile_endpoint.models import db, FormData, CaseData, Synclog, CaseIndex
 from mobile_endpoint.synclog.checksum import Checksum
 from mobile_endpoint.utils import json_format_datetime
-from tests.conftest import delete_all_data
+from tests.conftest import delete_all_data, rowsize, sql
 from tests.utils import create_synclog
 
 
 @pytest.mark.usefixtures("testapp", "sqldb", "db_reset")
+@sql
 class TestModels(object):
     def test_basic(self, testapp):
         form = FormData(id=str(uuid4()), domain='test', received_on=datetime.utcnow(),
@@ -76,7 +77,7 @@ class TestModels(object):
 
 @pytest.mark.usefixtures("testapp", "sqldb")
 class TestDetermineRowSizes(object):
-    @pytest.mark.skipif(True, reason="Not a real test. Only run this manually")
+    @rowsize('form')
     def test_table_size_form(self):
         """
         Insert 10000 rows into the form_data table. Run scripts/get_table_sizes.sh to
@@ -101,7 +102,7 @@ class TestDetermineRowSizes(object):
 
         db.session.bulk_save_objects(forms)
 
-    @pytest.mark.skipif(True, reason="Not a real test. Only run this manually")
+    @rowsize('case')
     def test_table_size_case(self):
         """
         Insert 10000 rows into the form_data table. Run scripts/get_table_sizes.sh to

--- a/prototype/tests/sql/test_receiver.py
+++ b/prototype/tests/sql/test_receiver.py
@@ -1,10 +1,12 @@
 import pytest
 from mobile_endpoint.models import FormData, CaseData, Synclog
 from mobile_endpoint.synclog.checksum import Checksum
+from tests.conftest import sql
 from tests.test_receiver import ReceiverTestMixin, DOMAIN
 
 
 @pytest.mark.usefixtures("testapp", "client", "sqldb", "db_reset")
+@sql
 class TestPostgresReceiver(ReceiverTestMixin):
 
     def _get_backend(self):

--- a/prototype/tests/sql/test_receiver.py
+++ b/prototype/tests/sql/test_receiver.py
@@ -2,6 +2,7 @@ import pytest
 from mobile_endpoint.models import FormData, CaseData, Synclog
 from mobile_endpoint.synclog.checksum import Checksum
 from tests.conftest import sql
+from tests.mock import BACKEND_SQL
 from tests.test_receiver import ReceiverTestMixin, DOMAIN
 
 
@@ -10,7 +11,7 @@ from tests.test_receiver import ReceiverTestMixin, DOMAIN
 class TestPostgresReceiver(ReceiverTestMixin):
 
     def _get_backend(self):
-        return 'sql'
+        return BACKEND_SQL
 
     def _assert_form(self, form_id, user_id, synclog_id=None):
         sql_form = FormData.query.get(form_id)

--- a/prototype/tests/sql/test_receiver.py
+++ b/prototype/tests/sql/test_receiver.py
@@ -4,7 +4,7 @@ from mobile_endpoint.synclog.checksum import Checksum
 from tests.test_receiver import ReceiverTestMixin, DOMAIN
 
 
-@pytest.mark.usefixtures("testapp", "client", "db_reset")
+@pytest.mark.usefixtures("testapp", "client", "sqldb", "db_reset")
 class TestPostgresReceiver(ReceiverTestMixin):
 
     def _get_backend(self):

--- a/prototype/tests/test_restore.py
+++ b/prototype/tests/test_restore.py
@@ -9,6 +9,7 @@ from mobile_endpoint.case.xml import V2
 
 from mobile_endpoint.models import Synclog
 from mobile_endpoint.restore import xml
+from tests.conftest import sql
 from tests.dummy import dummy_user, dummy_restore_xml
 from tests.mock import CaseFactory, CaseStructure
 from tests.utils import check_xml_line_by_line
@@ -17,6 +18,7 @@ DOMAIN = 'test_domain'
 
 
 @pytest.mark.usefixtures("testapp", "client", "sqldb", "db_reset")
+@sql
 class TestRestore(object):
     user_id = str(uuid4())
     case_id = str(uuid4())

--- a/prototype/tests/test_restore.py
+++ b/prototype/tests/test_restore.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import base64
-from datetime import datetime
 from uuid import uuid4
 
 import pytest
@@ -8,9 +7,8 @@ import time
 from mobile_endpoint.case import const
 from mobile_endpoint.case.xml import V2
 
-from mobile_endpoint.models import Synclog, db
+from mobile_endpoint.models import Synclog
 from mobile_endpoint.restore import xml
-from mobile_endpoint.synclog.checksum import Checksum
 from tests.dummy import dummy_user, dummy_restore_xml
 from tests.mock import CaseFactory, CaseStructure
 from tests.utils import check_xml_line_by_line
@@ -18,7 +16,7 @@ from tests.utils import check_xml_line_by_line
 DOMAIN = 'test_domain'
 
 
-@pytest.mark.usefixtures("testapp", "client", "db_reset")
+@pytest.mark.usefixtures("testapp", "client", "sqldb", "db_reset")
 class TestRestore(object):
     user_id = str(uuid4())
     case_id = str(uuid4())

--- a/prototype/tests/test_restore.py
+++ b/prototype/tests/test_restore.py
@@ -11,7 +11,7 @@ from mobile_endpoint.models import Synclog
 from mobile_endpoint.restore import xml
 from tests.conftest import sql
 from tests.dummy import dummy_user, dummy_restore_xml
-from tests.mock import CaseFactory, CaseStructure
+from tests.mock import CaseFactory, CaseStructure, BACKEND_SQL
 from tests.utils import check_xml_line_by_line
 
 DOMAIN = 'test_domain'
@@ -40,6 +40,7 @@ class TestRestore(object):
     def test_user_restore_with_case(self, testapp, client):
         with testapp.app_context():
             factory = CaseFactory(
+                BACKEND_SQL,
                 client,
                 domain=DOMAIN,
                 case_defaults={
@@ -95,6 +96,7 @@ class TestRestore(object):
         # update the case
         with testapp.app_context():
             factory = CaseFactory(
+                BACKEND_SQL,
                 client,
                 domain=DOMAIN,
                 case_defaults={


### PR DESCRIPTION
@czue

```
$ py.test -m <sql or couch> # only run the sql or couch tests
$ py.test --rowsize <form or case> # run the rowsize form or case tests
```
