### PR TITLE
Additional Mongo backend work

### DIFF
--- a/prototype/mobile_endpoint/backends/mongo/dao.py
+++ b/prototype/mobile_endpoint/backends/mongo/dao.py
@@ -76,7 +76,6 @@ class MongoDao(AbsctractDao):
         return []
 
     def get_open_case_ids(self, domain, owner_id):
-        # TODO: Build indexes on MongoCase fields!
         assert isinstance(owner_id, basestring)
         return [
             unicode(c.id) for c in

--- a/prototype/mobile_endpoint/backends/mongo/dao.py
+++ b/prototype/mobile_endpoint/backends/mongo/dao.py
@@ -67,13 +67,14 @@ class MongoDao(AbsctractDao):
         for c in MongoCase.objects(id__in=case_ids):
             yield c
 
+    @to_generic
     def get_reverse_indexed_cases(self, domain, case_ids):
         """
         Given a base list of case ids, gets all cases that reference the given cases (child cases)
         """
-        # TODO: There seems to be no test coverage for this function.
-        #       Returning an empty list still passes.
-        return []
+        cases = MongoCase.objects(domain=domain, indices__referenced_id__in=case_ids)
+        for c in cases:
+            yield c
 
     def get_open_case_ids(self, domain, owner_id):
         assert isinstance(owner_id, basestring)

--- a/prototype/mobile_endpoint/backends/mongo/dao.py
+++ b/prototype/mobile_endpoint/backends/mongo/dao.py
@@ -10,8 +10,7 @@ from mobile_endpoint.utils import get_with_lock
 class MongoDao(AbsctractDao):
 
     def commit_atomic_submission(self, xform, case_result):
-        # TODO: Save all in one bulk operation
-        # TODO: Are the forms, cases, and synclogs all supposed to be all or nothing?
+        # Ideally, the forms, cases, and synclogs would be saved all-or-nothing
 
         # form
         _, form = MongoForm.from_generic(xform)
@@ -101,9 +100,6 @@ class MongoDao(AbsctractDao):
         Given a list of case IDs, return a dict where the keys are the case ids
         and the values are the last server modified date of that case.
         """
-        # TODO: This is never called with a non empty case_ids...
-        # What type should case_ids be?
-        # Should this return a string or a datetime?
         objs = MongoCase.objects(id__in=case_ids).only('id', 'server_modified_on')
         return {unicode(o.id): o.server_modified_on for o in objs}
 

--- a/prototype/mobile_endpoint/backends/mongo/dao.py
+++ b/prototype/mobile_endpoint/backends/mongo/dao.py
@@ -62,8 +62,19 @@ class MongoDao(AbsctractDao):
 
     @to_generic
     def get_cases(self, case_ids, ordered=True):
-        for c in MongoCase.objects(id__in=case_ids):
-            yield c
+        # Assumes case_ids are strings.
+        cases = MongoCase.objects(id__in=case_ids)
+
+        if ordered:
+            # Mongo won't return the rows in any particular order so we need to order them ourselves
+            index_map = {UUID(id_): index for index, id_ in enumerate(case_ids)}
+            ordered_cases = [None] * len(case_ids)
+            for case in cases:
+                ordered_cases[index_map[case.id]] = case
+            cases = ordered_cases
+
+        return cases
+
 
     @to_generic
     def get_reverse_indexed_cases(self, domain, case_ids):

--- a/prototype/mobile_endpoint/backends/mongo/dao.py
+++ b/prototype/mobile_endpoint/backends/mongo/dao.py
@@ -58,9 +58,8 @@ class MongoDao(AbsctractDao):
             None, _get_case(id)
 
     def case_exists(self, id):
-        assert isinstance(id, UUID)
-        return MongoCase.objects(id=id).limit(1) is not None
-        # TODO: Test this
+        # This method isn't ever used by the receiver
+        return MongoCase.objects(id=UUID(id)).limit(1) is not None
 
     @to_generic
     def get_cases(self, case_ids, ordered=True):

--- a/prototype/mobile_endpoint/backends/mongo/models.py
+++ b/prototype/mobile_endpoint/backends/mongo/models.py
@@ -55,8 +55,16 @@ class MongoCaseIndex(EmbeddedDocument):
     referenced_type = StringField()
     referenced_id = UUIDField()
 
+
 class MongoCase(DynamicDocument, ToFromGeneric):
-    meta = {'collection': 'cases'}
+    meta = {
+        'collection': 'cases',
+        'indexes': [
+            'domain',
+            'owner_id',
+            'closed',
+        ],
+    }
     id = UUIDField(primary_key=True)
     domain = StringField()
     closed = BooleanField(default=False)

--- a/prototype/mobile_endpoint/backends/sql/dao.py
+++ b/prototype/mobile_endpoint/backends/sql/dao.py
@@ -72,6 +72,7 @@ class SQLDao(AbsctractDao):
 
     @to_generic
     def get_cases(self, case_ids, ordered=False):
+        # TODO: Should this function really be changing the default value of ordered (GenericDao has ordered=True)?
         cases = CaseData.query.filter(CaseData.id.in_(case_ids)).all()
         if ordered:
             # SQL won't return the rows in any particular order so we need to order them ourselves

--- a/prototype/mobile_endpoint/views/receiver.py
+++ b/prototype/mobile_endpoint/views/receiver.py
@@ -42,5 +42,6 @@ def _receiver(domain, backend):
             case_result = process_cases_in_form(xform, dao)
 
         dao.commit_atomic_submission(xform, case_result)
+        # This doesn't do anything with dirtyness flags. Should it?
 
     return get_open_rosa_response(xform, None, None)

--- a/prototype/tests/test_receiver.py
+++ b/prototype/tests/test_receiver.py
@@ -98,6 +98,7 @@ class ReceiverTestMixin(object):
         self._assert_form(form_id, user_id, synclog_id)
         self._assert_case(case_id, user_id)
         self._assert_synclog(synclog_id, case_ids=[case_id])
+        assert get_dao(self._get_backend()).case_exists(case_id) is True
 
     def test_update_case(self, testapp, client):
         user_id = str(uuid4())


### PR DESCRIPTION
Can review commit-by-commit.

One question that I have: I've only indexed the fields that the receiver/restore functions need to query. So besides the index on id for each document, I've only added indexes for case `domain`, `owner_id`, and `closed`. @czue or @snopoke , do you think other fields would end up being indexed (like the form `domain` field for example)?
