### PR TITLE
Fix default behavior of Dao.get_cases()

### DIFF
--- a/prototype/mobile_endpoint/backends/couch/dao.py
+++ b/prototype/mobile_endpoint/backends/couch/dao.py
@@ -59,7 +59,7 @@ class CouchDao(AbsctractDao):
         return CouchCase.get_db().doc_exist(id)
 
     @to_generic
-    def get_cases(self, case_ids, ordered=True):
+    def get_cases(self, case_ids, ordered=False):
         for row in CouchCase.view('_all_docs', keys=case_ids, include_docs=True):
             yield row
 

--- a/prototype/mobile_endpoint/backends/mongo/dao.py
+++ b/prototype/mobile_endpoint/backends/mongo/dao.py
@@ -73,7 +73,8 @@ class MongoDao(AbsctractDao):
                 ordered_cases[index_map[case.id]] = case
             cases = ordered_cases
 
-        return cases
+        for c in cases:
+            yield c
 
 
     @to_generic
@@ -89,7 +90,7 @@ class MongoDao(AbsctractDao):
         assert isinstance(owner_id, basestring)
         return [
             unicode(c.id) for c in
-            MongoCase.objects(domain=domain, owner_id=UUID(owner_id), closed=False).only('id').all()
+            MongoCase.objects(domain=domain, owner_id=UUID(owner_id), closed=False).only('id')
         ]
 
     def get_case_ids_modified_with_owner_since(self, domain, owner_id, reference_date):

--- a/prototype/mobile_endpoint/backends/mongo/dao.py
+++ b/prototype/mobile_endpoint/backends/mongo/dao.py
@@ -61,7 +61,7 @@ class MongoDao(AbsctractDao):
         return MongoCase.objects(id=UUID(id)).limit(1) is not None
 
     @to_generic
-    def get_cases(self, case_ids, ordered=True):
+    def get_cases(self, case_ids, ordered=False):
         # Assumes case_ids are strings.
         cases = MongoCase.objects(id__in=case_ids)
 

--- a/prototype/mobile_endpoint/backends/sql/dao.py
+++ b/prototype/mobile_endpoint/backends/sql/dao.py
@@ -72,7 +72,6 @@ class SQLDao(AbsctractDao):
 
     @to_generic
     def get_cases(self, case_ids, ordered=False):
-        # TODO: Should this function really be changing the default value of ordered (GenericDao has ordered=True)?
         cases = CaseData.query.filter(CaseData.id.in_(case_ids)).all()
         if ordered:
             # SQL won't return the rows in any particular order so we need to order them ourselves

--- a/prototype/mobile_endpoint/dao.py
+++ b/prototype/mobile_endpoint/dao.py
@@ -64,7 +64,7 @@ class AbsctractDao(object):
         pass
 
     @abstractmethod
-    def get_cases(self, case_ids, ordered=True):
+    def get_cases(self, case_ids, ordered=False):
         pass
 
     @abstractmethod


### PR DESCRIPTION
Also fixes an issue with `MongoDao.get_cases()` return type (it was returning a QuerySet when the `to_generic` decorator was expecting a list or generator).
@snopoke cc @dannyroberts 
