### PR TITLE
Fix Mongo backend

### DIFF
--- a/prototype/requirements.txt
+++ b/prototype/requirements.txt
@@ -17,3 +17,4 @@ jsonobject-couchdbkit==0.6.5.7
 pytz
 pymongo
 mongoengine
+python-dateutil

--- a/tsung/backends.py
+++ b/tsung/backends.py
@@ -237,6 +237,11 @@ class PrototypeMongo(Backend):
         print('Running mongo db sync')
         self._run_manage_py('syncmongo')
 
+        # The mongo backend uses sql for some things, like OwnershipCleanlinessFlags
+        print('Running db upgrade')
+        self._run_manage_py('db', 'upgrade',)
+
+
     def load_data(self, dest_folder):
         loader = DataLoader(
             dest_folder,


### PR DESCRIPTION
@snopoke cc @dannyroberts 

This `python-dateutil` bug was a tricky one to find:
Locally everything was fine, but on the cloud MongoEngine's `DateTimeField` was choking on validating values like `"2015-08-07T19:39:41Z"`. It wasn't until looking at the MongoEngine source that I discovered that `DateTimeField` uses `python-dateutil` for parsing if available, and otherwise uses `time.strptime`. Locally I was using just one virtual environment for the `tsung` half and the `prototype` half of the repo. `python-dateutil` was already a requirement for the `tsung` half, which is why I wasn't getting the error locally.
